### PR TITLE
Fix scheduler startup and dependency pin

### DIFF
--- a/main.py
+++ b/main.py
@@ -150,7 +150,10 @@ def schedule_daily_tasks():
             replace_existing=True
         )
 
-if __name__ == '__main__':
+async def on_startup(dp):
     schedule_daily_tasks()
     scheduler.start()
-    executor.start_polling(dp, skip_updates=True)
+
+
+if __name__ == '__main__':
+    executor.start_polling(dp, skip_updates=True, on_startup=on_startup)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiogram==2.25.2
 apscheduler
 fpdf
+aiohttp==3.8.6


### PR DESCRIPTION
## Summary
- ensure the daily scheduler starts after the event loop begins
- pin `aiohttp` to a version compatible with aiogram

## Testing
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684757ede6a883329e1489813e930edb